### PR TITLE
Fix a bug where the region configuration parameter is ignored.

### DIFF
--- a/src/main/java/com/github/seanroy/plugins/LambduhMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/LambduhMojo.java
@@ -43,7 +43,7 @@ public class LambduhMojo extends AbstractMojo {
     @Parameter(required = true, defaultValue = "${functionCode}")
     private String functionCode;
 
-    @Parameter(property = "region", defaultValue = "us-east-1")
+    @Parameter(alias = "region", property = "region", defaultValue = "us-east-1")
     private String regionName;
 
     @Parameter(property = "s3Bucket", defaultValue = "lambda-function-code")


### PR DESCRIPTION
The region configuration parameter is ignored. (Instead, the "regionName" parameter works.)

This patch fix it.