### PR TITLE
Adding ability to pull creds from the default provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 *.asc
 *.jar
 *.swp
+.idea
+*.iml
 target
 pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.seanroy</groupId>
   <artifactId>lambduh-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3-SNAPSHOT</version>
   
   <name>lambduh-maven-plugin Maven Mojo</name>
   <description>A maven plugin that deploys functions to AWS Lambda</description>
@@ -25,7 +25,11 @@
       <organizationUrl>https://github.com/SeanRoy/lambduh-maven-plugin</organizationUrl>
     </developer>
   </developers>
-  
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <scm>
     <connection>scm:git:git@github.com:SeanRoy/lambduh-maven-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:SeanRoy/lambduh-maven-plugin.git</developerConnection>

--- a/src/main/java/com/github/seanroy/plugins/LambduhMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/LambduhMojo.java
@@ -8,6 +8,7 @@ package com.github.seanroy.plugins;
 import java.io.File;
 import java.util.regex.Pattern;
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -84,14 +85,18 @@ public class LambduhMojo extends AbstractMojo {
      * The entry point into the AWS lambda function.
      */
     public void execute() throws MojoExecutionException {
+        DefaultAWSCredentialsProviderChain defaultChain = new DefaultAWSCredentialsProviderChain();
         if (accessKey != null && secretKey != null) {
             credentials = new BasicAWSCredentials(accessKey, secretKey);
-            s3Client = new AmazonS3Client(credentials);
-            lambdaClient = new AWSLambdaClient(credentials);
-        } else {
-            s3Client = new AmazonS3Client();
-            lambdaClient = new AWSLambdaClient();
         }
+        else if (defaultChain.getCredentials()!=null)
+        {
+            credentials = defaultChain.getCredentials();
+        }
+
+        s3Client = (credentials==null)?new AmazonS3Client():new AmazonS3Client(credentials);
+        lambdaClient = (credentials==null)?new AWSLambdaClient():new AWSLambdaClient(credentials);
+
 
         region = Region.getRegion(Regions.fromName(regionName));
         lambdaClient.setRegion(region);


### PR DESCRIPTION
Please consider the attached pull request.  It does the following things:

1) Trys to pull credentials using DefaultAWSCredentialsProviderChain.  This allows it to work with the credentials files created by the AWS CLI scripts, environmental variables, Java system properties, and also, if it is running on an EC2 box, to use the Role-based credentials.  This is only used if the explicit variables aren't set so it _should_ be backwards compatible
2) Updated the version number, made it a snapshot for the moment
3) Added an explicit source encoding on the pom file so maven stops whining
4) Added exclusions for intellij files to the .gitignore file

Thanks!

Chris
